### PR TITLE
Fix: update BaseHook import

### DIFF
--- a/airflow_dbt_cta/hooks/dbt_hook.py
+++ b/airflow_dbt_cta/hooks/dbt_hook.py
@@ -4,7 +4,7 @@ import signal
 import subprocess
 import json
 from airflow.exceptions import AirflowException
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 
 class DbtCliHook(BaseHook):


### PR DESCRIPTION
The import path for BaseHook has changed. This is updating it to the new path since the old path is deprecated and spitting out a bunch of error/warning logs.