### PR TITLE
feat: make 'full_refresh' parameter a template field

### DIFF
--- a/airflow_dbt_cta/__version__.py
+++ b/airflow_dbt_cta/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 9)
+VERSION = (0, 0, 10)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/airflow_dbt_cta/operators/dbt_operator.py
+++ b/airflow_dbt_cta/operators/dbt_operator.py
@@ -39,7 +39,7 @@ class DbtBaseOperator(BaseOperator):
 
     ui_color = '#d6522a'
 
-    template_fields = ['env_vars', 'vars', 'skip']
+    template_fields = ['env_vars', 'vars', 'skip', 'full_refresh']
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION
Adding this as a template field will allow us to pass in if models should be run with the full-refresh flag using a DAG param. This is needed because DAG params are only available at runtime, so that means we have to pass it in as a Jinja template like so 
```
full_refresh = "{{ params.should_full_refresh }}"
```